### PR TITLE
Using the word runtime makes more sense

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # CatYou - Deno
-Every Framework Needs a Cat API
+Every Runtime Needs a Cat API
 
 [![Build Status](https://travis-ci.org/SuperC03/CatYou-Deno.svg?branch=master)](https://travis-ci.org/SuperC03/CatYou-Deno)
 


### PR DESCRIPTION
Using the word runtime makes more than calling it a framework as deno doesn't provide a framework of functions or commands for the user to use, it provides them with a runtime enviroment to run in.